### PR TITLE
Add a check to not reprocess all data

### DIFF
--- a/profiles/profile_utils.py
+++ b/profiles/profile_utils.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 import argparse
 
@@ -15,3 +16,28 @@ def get_args():
     args = parser.parse_args()
 
     return args
+
+
+def get_pipeline_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-o",
+        "--overwrite",
+        action="store_true",
+        help="reprocess and overwrite all data",
+    )
+    args = parser.parse_args()
+
+    return args
+
+
+def find_incomplete_plates(
+    plates, output_dir="backend", file_match="normalized_feature_select.csv.gz"
+):
+    incomplete_plates = []
+    for plate in plates:
+        plate_data_dir = pathlib.PurePath(f"{output_dir}/{plate}/")
+        dir_contents = os.listdir(plate_data_dir)
+        if not any([file_match in x for x in dir_contents]):
+            incomplete_plates.append(plate)
+    return incomplete_plates


### PR DESCRIPTION
Because of the platemap issues outlined in #24, not all plates were funneled through the image-based profiling pipeline. Rather than having to rerun _all plates_ again, I add a check to see if the final file was created for each profile. 

Note also the addition of an `--overwrite` flag to retain previous reprocessing behavior. Overwrite defaults to False.