### PR TITLE
Update DVC location

### DIFF
--- a/.dvc/config
+++ b/.dvc/config
@@ -1,4 +1,4 @@
 [core]
     remote = cellpainting-datasets
 ['remote "cellpainting-datasets"']
-    url = s3://cellpainting-datasets/lincs-cell-painting/.dvc/cache
+    url = s3://cellpainting-gallery/cpg0004-lincs/broad/workspace/software/lincs-cell-painting_DVC

--- a/profiles/README.md
+++ b/profiles/README.md
@@ -137,6 +137,7 @@ To access the files stored via DVC, you will need to created a IAM user with the
         }
     ]
 }
+```
 
 ### DeepProfiler-derived profiles
 

--- a/profiles/README.md
+++ b/profiles/README.md
@@ -118,6 +118,26 @@ git lfs pull
 dvc pull
 ```
 
+**Note:** The DVC cache is stored in an AWS S3 bucket. 
+To access the files stored via DVC, you will need to created a IAM user with the `AmazonS3ReadOnlyAccess` policy attached:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:Get*",
+                "s3:List*",
+                "s3-object-lambda:Get*",
+                "s3-object-lambda:List*"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+
 ### DeepProfiler-derived profiles
 
 TBD

--- a/profiles/README.md
+++ b/profiles/README.md
@@ -118,7 +118,10 @@ git lfs pull
 dvc pull
 ```
 
-**Note:** The DVC remote is an AWS S3 bucket. 
+**Note:** The DVC remote is an AWS S3 bucket. You must have aws cli installed and configured (see details).
+
+<details>
+
 To access the files stored via DVC, you will need to created a AWS IAM user, who should, minimally, be able to Get objects and List buckets.
 One way of achieving this is to attach the `AmazonS3ReadOnlyAccess` policy, which is:
 
@@ -141,6 +144,8 @@ One way of achieving this is to attach the `AmazonS3ReadOnlyAccess` policy, whic
 ```
 
 (Note that the `s3-object-lambda:Get*` and `s3-object-lambda:List*` are not required but they don't hurt)
+
+</details>
 
 ### DeepProfiler-derived profiles
 

--- a/profiles/README.md
+++ b/profiles/README.md
@@ -118,8 +118,9 @@ git lfs pull
 dvc pull
 ```
 
-**Note:** The DVC cache is stored in an AWS S3 bucket. 
-To access the files stored via DVC, you will need to created a IAM user with the `AmazonS3ReadOnlyAccess` policy attached:
+**Note:** The DVC remote is an AWS S3 bucket. 
+To access the files stored via DVC, you will need to created a AWS IAM user, who should, minimally, be able to Get objects and List buckets.
+One way of achieving this is to attach the `AmazonS3ReadOnlyAccess` policy, which is:
 
 ```json
 {
@@ -138,6 +139,8 @@ To access the files stored via DVC, you will need to created a IAM user with the
     ]
 }
 ```
+
+(Note that the `s3-object-lambda:Get*` and `s3-object-lambda:List*` are not required but they don't hurt)
 
 ### DeepProfiler-derived profiles
 


### PR DESCRIPTION
I ran this command to copy the DVC files to a new location

```sh
aws s3 sync   \
  --profile jump-cp-role  \
  --acl bucket-owner-full-control  \
  --metadata-directive REPLACE \
  s3://cellpainting-datasets/lincs-cell-painting/.dvc/cache/ \
  s3://cellpainting-gallery/cpg0004-lincs/broad/workspace/software/lincs-cell-painting_DVC/
```

The rest of the files (other than `.dvc/cache`) in  `s3://cellpainting-datasets/lincs-cell-painting/` seem to be a git clone of this repo (see below)

<img width="572" alt="image" src="https://user-images.githubusercontent.com/1210428/177452158-fc8c8917-b22f-46d6-b9bf-65f9b589749c.png">

Note: At present, I still don't have a good way to provide permissions to push to this new location (i.e. unlike with `s3://cellpainting-datasets/` where I could give @gwaybio AWS credentials to push to the S3 bucket, I can't do that yet with `s3://cellpainting-gallery/`.)  

If that's fine with you @gwaybio, please merge this PR (and then I will delete  `s3://cellpainting-datasets/lincs-cell-painting/`)
